### PR TITLE
Added warehouse and role connection options to the Snowflake connecti…

### DIFF
--- a/python/data-source/sedona-snowflake-example.ipynb
+++ b/python/data-source/sedona-snowflake-example.ipynb
@@ -82,7 +82,9 @@
     "\n",
     "#Context options\n",
     "database = '<SNOWFLAKE_DB_NAME>'\n",
-    "schema = '<DB_SCHEMA>'"
+    "schema = '<DB_SCHEMA>'\n",
+    "warehouse = '<WAREHOUSE_NAME>'\n",
+    "role = '<ROLE_NAME>'"
    ]
   },
   {
@@ -92,7 +94,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sfOptions = {\"sfUrl\": snowflake_url, \"sfUser\": username, \"sfPassword\" : password, \"sfDatabase\": database, \"sfSchema\": schema}"
+    "sfOptions = {\"sfUrl\": snowflake_url, \n",
+    "             \"sfUser\": username, \n",
+    "             \"sfPassword\" : password, \n",
+    "             \"sfDatabase\": database, \n",
+    "             \"sfSchema\": schema,\n",
+    "             \"sfWarehouse\":warehouse,\n",
+    "             \"sfRole\":role}"
    ]
   },
   {


### PR DESCRIPTION
Added warehouse and role connection options to the Snowflake connection example notebook.
Reformatted `sfOptions` dict for legibility.

`Warehouse` was required when I was testing.
It's a best practice to specify the `role` as default roles usually lack appropriate privileges.